### PR TITLE
Fix some generation issues and add index files for models and services

### DIFF
--- a/ng-spring-data-rest.js
+++ b/ng-spring-data-rest.js
@@ -298,6 +298,7 @@ async function generateTypeScriptFromSchema(schemas, entities, outputDir, modelD
         const serviceTemplateData = {
             'className': className,
             'classNameKebab': classNameKebab,
+            'modelDir': modelDir,
             'repositoryName': entity
         };
         const renderedService = mustache.render(serviceTemplateString,

--- a/ng-spring-data-rest.js
+++ b/ng-spring-data-rest.js
@@ -263,42 +263,41 @@ function generateTypeScriptFromSchema(schemas, entities, outputDir, modelDir, se
                 // Add I to the beginning of each class name to indicate interface.
                 tsFile = tsFile.replace(REGEXP_TYPESCRIPT_INTERFACE_NAME,
                                         '$1I$2$3');
-                
+
                 // Construct filename for generated interface file.
                 let matches = tsFile.match(REGEXP_TYPESCRIPT_INTERFACE_NAME);
-                
+
                 const interfaceName = matches[2];
-                const interfaceNameLower = interfaceName.toLowerCase();
+                const interfaceNameKebab = _.kebabCase(interfaceName);
                 const className = interfaceName.substr(1);
-                const classNameLower = className.toLowerCase();
-                const classNameSnake = _.camelCase(className);
-                
+                const classNameKebab = _.kebabCase(className);
+
                 // Write interface file.
-                const interfaceFileName = `${interfaceNameLower}.d.ts`;
+                const interfaceFileName = `${interfaceNameKebab}.d.ts`;
                 fs.writeFileSync(`${outputDir}/${modelDir}/${interfaceFileName}`,
                                  tsFile);
-                
+
                 // Create class from template file.
                 const classTemplateData = {
                     'interfaceName': interfaceName,
-                    'interfaceNameLower': interfaceNameLower,
+                    'interfaceNameKebab': interfaceNameKebab,
                     'className': className
                 };
                 const renderedClass = mustache.render(classTemplateString,
                                                       classTemplateData);
-                const classFileName = `${classNameSnake}.ts`;
+                const classFileName = `${classNameKebab}.ts`;
                 fs.writeFileSync(`${outputDir}/${modelDir}/${classFileName}`,
                                  renderedClass);
-                
+
                 // Create service from template file.
                 const serviceTemplateData = {
                     'className': className,
-                    'classNameLower': classNameLower,
+                    'classNameKebab': classNameKebab,
                     'repositoryName': entity
                 };
                 const renderedService = mustache.render(serviceTemplateString,
                                                         serviceTemplateData);
-                const serviceFileName = `${classNameSnake}.service.ts`;
+                const serviceFileName = `${classNameKebab}.service.ts`;
                 fs.writeFileSync(`${outputDir}/${serviceDir}/${serviceFileName}`,
                                  renderedService);
             });

--- a/ng-spring-data-rest.js
+++ b/ng-spring-data-rest.js
@@ -11,12 +11,8 @@
 
 'use strict';
 
-// Declare constants
-const REGEXP_TYPESCRIPT_INTERFACE_NAME = /^(export interface )(\w+)( {)$/m;
-const PATH_CLASS_TEMPLATE = './templates/class';
-const PATH_SERVICE_TEMPLATE = './templates/service';
-
 // Load dependencies
+const path = require('path');
 const axios = require('axios').default;
 const axiosCookieJarSupport = require('axios-cookiejar-support').default;
 const tough = require('tough-cookie');
@@ -25,6 +21,11 @@ const jsonTs = require('json-schema-to-typescript');
 const fs = require('fs');
 const mustache = require('mustache');
 const _ = require('lodash');
+
+// Declare constants
+const REGEXP_TYPESCRIPT_INTERFACE_NAME = /^(export interface )(\w+)( {)$/m;
+const PATH_CLASS_TEMPLATE = path.join(__dirname, './templates/class');
+const PATH_SERVICE_TEMPLATE = path.join(__dirname, './templates/service');
 
 // Declare global variables
 let axiosInstance = undefined;

--- a/ng-spring-data-rest.js
+++ b/ng-spring-data-rest.js
@@ -19,6 +19,7 @@ const tough = require('tough-cookie');
 const qs = require('qs');
 const jsonTs = require('json-schema-to-typescript');
 const fs = require('fs');
+const fsExtra = require('fs-extra');
 const mustache = require('mustache');
 const _ = require('lodash');
 
@@ -81,6 +82,10 @@ async function doGenerate(options) {
                  {recursive: true});
     fs.mkdirSync(`${options.outputDir}/${options.serviceDir}`,
                  {recursive: true});
+
+    // Empty output directory
+    fsExtra.emptyDirSync(`${options.outputDir}/${options.modelDir}`);
+    fsExtra.emptyDirSync(`${options.outputDir}/${options.serviceDir}`);
     
     // Process JSON schemas based on configuration.
     preProcessSchemas(jsonSchemas, options);

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "argparse": "^1.0.10",
     "axios": "^0.19.2",
     "axios-cookiejar-support": "^0.5.1",
+    "fs-extra": "^8.1.0",
     "json-schema-to-typescript": "^8.0.1",
     "lodash": "^4.17.15",
     "mustache": "^4.0.0",

--- a/templates/class
+++ b/templates/class
@@ -1,5 +1,5 @@
 import {Resource} from '@lagoshny/ngx-hal-client';
-import {$$@interfaceName@$$} from './$$@interfaceNameLower@$$';
+import {$$@interfaceName@$$} from './$$@interfaceNameKebab@$$';
 
 export class $$@className@$$ extends Resource implements $$@interfaceName@$$ {
     constructor() {

--- a/templates/models
+++ b/templates/models
@@ -1,0 +1,3 @@
+$$@#models@$$
+export { $$@modelClass@$$ } from './$$@modelDir@$$/$$@modelFile@$$';
+$$@/models@$$

--- a/templates/service
+++ b/templates/service
@@ -2,7 +2,9 @@ import {Injectable, Injector} from '@angular/core';
 import {RestService} from '@lagoshny/ngx-hal-client';
 import {$$@className@$$} from '../model/$$@classNameKebab@$$';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root',
+})
 export class $$@className@$$Service extends RestService<$$@className@$$> {
   constructor(injector: Injector) {
     super($$@className@$$, '$$@repositoryName@$$', injector);

--- a/templates/service
+++ b/templates/service
@@ -1,6 +1,6 @@
 import {Injectable, Injector} from '@angular/core';
 import {RestService} from '@lagoshny/ngx-hal-client';
-import {$$@className@$$} from '../model/$$@classNameKebab@$$';
+import {$$@className@$$} from '../$$@modelDir@$$/$$@classNameKebab@$$';
 
 @Injectable({
   providedIn: 'root',

--- a/templates/service
+++ b/templates/service
@@ -1,6 +1,6 @@
 import {Injectable, Injector} from '@angular/core';
 import {RestService} from '@lagoshny/ngx-hal-client';
-import {$$@className@$$} from '../model/$$@classNameLower@$$';
+import {$$@className@$$} from '../model/$$@classNameKebab@$$';
 
 @Injectable()
 export class $$@className@$$Service extends RestService<$$@className@$$> {

--- a/templates/services
+++ b/templates/services
@@ -1,0 +1,3 @@
+$$@#services@$$
+export { $$@modelClass@$$Service } from './$$@serviceDir@$$/$$@modelFile@$$.service';
+$$@/services@$$


### PR DESCRIPTION
Hi!

Your code works as intended but has some issues, that this request fixes:
- The paths to the templates were relative to from where the script is executed. They are now relative to the path of the script.
- The services were not provided in any module, so they could not be used immediately. I solved this by providing them as root.
- The file names did not follow the Angular style guide. They are now in kabab case following the spec.
- The model model-dir argument was missing in the template, which caused problems when it was not set to default.

In addition to that, I added two index files exporting all models and services. This should allow cleaner imports of the generated code. I also clean the output folder before starting the generation.

Please consider merging this and then increasing the version number. Thanks!

Best,
Fabian