### PR TITLE
Fix problems with alps schema and repository name

### DIFF
--- a/ng-spring-data-rest.js
+++ b/ng-spring-data-rest.js
@@ -271,7 +271,7 @@ async function collectAlpsAndPopulateNames(entities) {
         await axiosInstance.get(`profile/${key}`)
             .then(response => {
                 element['alps'] = response.data['alps'];
-                element['name'] = element['alps']['descriptor'][0]['id'].match(
+                element['name'] = element['alps']['descriptors'][0]['id'].match(
                     REGEXP_OWN_ENTITY_NAME)[1];
             })
             .catch(() => {
@@ -306,7 +306,7 @@ function preProcessSchemas(entities, config) {
  * @returns {*} The modified class.
  */
 function postProcessTypeScriptFiles(entities, entity, renderedClass, modelDir) {
-    for (const property of entity['alps']['descriptor'][0]['descriptor']) {
+    for (const property of entity['alps']['descriptors'][0]['descriptors']) {
         if ('rt' in property) {
             const propertyName = property['name'];
             let referencedEntity = property['rt'].match(REGEXP_RT_ENTITY_NAME)[0];
@@ -411,7 +411,7 @@ async function generateTypeScriptFromSchema(entities, outputDir, modelDir, servi
             'className': className,
             'classNameKebab': classNameKebab,
             'modelDir': modelDir,
-            'repositoryName': element
+            'repositoryName': element.repository
         };
         const renderedService = mustache.render(serviceTemplateString,
                                                 serviceTemplateData);


### PR DESCRIPTION
I'm not exactly sure if you are using a different Spring version that makes use of a different Alps spec, but I found two issues with slightly wrong property names. Can you take a look at the changes, test it yourself and consider merging them?

This commit fixes two issues:
- The Alps schemas basically contain a list of descriptors, that you use to generate the model files and services. However, the property name is *descriptor**s*** instead of *descriptor*
- When building a service, the repository name is not represented by the correct property. The property that you are passing is an object and not a string, which causes the resulting service to break.