### PR TITLE
Add option to avoid the generation of trivial type aliases

### DIFF
--- a/ng-spring-data-rest
+++ b/ng-spring-data-rest
@@ -117,6 +117,13 @@ argParser.addArgument(
         action: 'storeTrue'
     });
 argParser.addArgument(
+    ['--no-trivial-types'],
+    {
+        help: 'A switch to not generate aliases for types that are not referenced (e.g. string, number or boolean)',
+        dest: 'noTrivialTypes',
+        action: 'storeTrue'
+    });
+argParser.addArgument(
     ['--output-dir'],
     {
         help: 'Path of the output directory. If the directory does not exist, it is created.\n' +

--- a/ng-spring-data-rest.js
+++ b/ng-spring-data-rest.js
@@ -292,6 +292,28 @@ function preProcessSchemas(entities, config) {
         if (config.noAdditionalProperties) {
             entities[key].schema.additionalProperties = false;
         }
+        if (config.noTrivialTypes) {
+            removeTrivialTitles(entities[key].schema.properties || {});
+            removeTrivialTitles(entities[key].schema.definitions || {});
+        }
+    }
+}
+
+/**
+ * Remove the title properties from object attributes that do not have a $ref property set.
+ * This causes json-schema-to-typescript not to generate aliases for trivial types like string, number or boolean.
+ *
+ * @param object
+ */
+function removeTrivialTitles(object) {
+    for (const key of Object.keys(object)) {
+        const property = object[key];
+        if (!property['$ref']) {
+            delete property.title;
+        }
+        if (property.properties) {
+            removeTrivialTitles(property.properties);
+        }
     }
 }
 


### PR DESCRIPTION
The generator creates a type alias for each property of a resource. This list tends to be really long and doesn't really make sense when just referencing a `string` or `number`. The reason for that behaviour seems to be that Spring adds a title property even when an attribute is not a referenced class.

This change adds an optional schema preprocessing step that simply removes that property from attributes that don't reference another entity.